### PR TITLE
remove elvis from build

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,1 @@
-{plugins, [{rebar3_elvis_plugin, {git, "https://github.com/deadtrickster/rebar3_elvis_plugin.git", "master"}}]}.
+


### PR DESCRIPTION
remove plugin dependency. This break on builds with Erlang >= 22.