### PR TITLE
evaluated VSN

### DIFF
--- a/src/rebar3_archive_plugin.erl
+++ b/src/rebar3_archive_plugin.erl
@@ -39,7 +39,7 @@ do(State) ->
   Res.
 
 archive(State, App) ->
-  Vsn = rebar_app_info:original_vsn(App),
+  Vsn = rebar_app_info:vsn(App),
   Name = rebar_app_info:name(App),
 
   Dir = to_string([Name, "-", Vsn]),


### PR DESCRIPTION
in app.src files VSN can be unevaluated (it for example can be {file, "filename"}), so taking VSN from .src file via `rebar_app_info:original_vsn/1` is not ideal. Instead VSN should be taken from finished .app file via `rebar_app_info:vsn/1`